### PR TITLE
Fix import of `from deepspeech.model import Model`

### DIFF
--- a/src/deepspeech_node.py
+++ b/src/deepspeech_node.py
@@ -1,4 +1,5 @@
-from deepspeech import Model
+
+from deepspeech.model import Model
 import sys
 import wave
 import struct


### PR DESCRIPTION
This fixes the code with deepspeech==0.1.0 which I installed an hour ago. 